### PR TITLE
Fix fan speed offset on Narwal Freo Z (product key hEA7OEshlx)

### DIFF
--- a/custom_components/narwal/narwal_client/client.py
+++ b/custom_components/narwal/narwal_client/client.py
@@ -39,6 +39,8 @@ from .const import (
     CleanMode,
     FanLevel,
     MopHumidity,
+    get_fan_wire_value,
+
 )
 from .models import CommandResponse, NarwalState
 
@@ -469,7 +471,7 @@ class NarwalClient:
             + _make_protobuf_varint(2, passes)
             + _make_protobuf_varint(3, 1 if vacuum_on else 0)
             + _make_protobuf_varint(4, 1 if mop_on else 2)
-            + _make_protobuf_varint(5, fan_level.value)
+            + _make_protobuf_varint(5, get_fan_wire_value(self.product_key, fan_level))
             + _make_protobuf_varint(6, mop_humidity.value)
             + _make_protobuf_varint(7, 1)
             + _make_protobuf_varint(8, 1)
@@ -553,7 +555,8 @@ class NarwalClient:
         return await self.send_command(TOPIC_CMD_RECALL)
 
     async def set_fan_speed(self, level: FanLevel) -> CommandResponse:
-        extra = _make_protobuf_varint(1, level.value)
+        wire = get_fan_wire_value(self.product_key, level)
+        extra = _make_protobuf_varint(1, wire)
         return await self.send_command(TOPIC_CMD_SET_FAN_LEVEL, extra)
 
     async def set_mop_humidity(self, level: MopHumidity) -> CommandResponse:
@@ -711,3 +714,4 @@ class NarwalClient:
             client.disconnect()
 
         return discovered
+

--- a/custom_components/narwal/narwal_client/const.py
+++ b/custom_components/narwal/narwal_client/const.py
@@ -79,10 +79,33 @@ class WorkingStatus(IntEnum):
 
 
 class FanLevel(IntEnum):
+    """Logical fan-level names used inside the integration.
+
+    The underlying wire-protocol value differs per model — see
+    FAN_LEVEL_WIRE_VALUES below. Do not use .value directly when
+    building MQTT payloads; use get_fan_wire_value(product_key, level).
+    """
     QUIET = 0
     NORMAL = 1
     STRONG = 2
     MAX = 3
+
+
+# Product keys known to use the "shifted" wire mapping (1..4 instead of 0..3).
+# Confirmed via MITM of the Narwal app on:
+#   - Freo Z (hEA7OEshlx) — captured 2026-05
+#
+# Mapping reference (sent payload last varint after the auth frame):
+#   Freo X Ultra (EHf6cRNRGT): 0=Quiet, 1=Normal, 2=Strong, 3=Max
+#   Freo Z       (hEA7OEshlx): 1=Quiet, 2=Normal, 3=Strong, 4=Max
+SHIFTED_FAN_MODELS = frozenset({"hEA7OEshlx"})
+
+
+def get_fan_wire_value(product_key: str, level: "FanLevel") -> int:
+    """Translate a logical FanLevel to the wire value for this model."""
+    if product_key in SHIFTED_FAN_MODELS:
+        return level.value + 1
+    return level.value
 
 
 class MopHumidity(IntEnum):


### PR DESCRIPTION
## Problem
On Narwal Freo Z (product key `hEA7OEshlx`) the fan speed selector
is off by one step:
- Setting "Max" actually runs the vacuum at Strong level
- Setting "Strong" actually runs Normal
- Setting "Normal" actually runs Quiet
- Setting "Quiet" does nothing

## Root cause
Captured the official Narwal Android app's MQTT traffic via a TLS
MITM proxy. The app sends fan_level values 1–4 instead of the 0–3
used by Freo X Ultra:

| UI label | Freo X Ultra | Freo Z |
|----------|-------------|--------|
| Quiet    | 0           | 1      |
| Normal   | 1           | 2      |
| Strong   | 2           | 3      |
| Max      | 3           | 4      |

Verified by capturing four consecutive clean/set_fan_level PUBLISH
payloads from the official Narwal app.

## Fix
Added `SHIFTED_FAN_MODELS` set and `get_fan_wire_value()` helper in
`narwal_client/const.py`. Callers in `narwal_client/client.py` now
use the helper instead of `level.value` directly.

Default behavior for any non-listed product key is unchanged —
Freo X Ultra and other models still send 0–3.

## Testing
Tested on Freo Z (`hEA7OEshlx`) — fan speeds now match the labels.